### PR TITLE
feat: adds tfe token secret to the int test config for GCB

### DIFF
--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -27,3 +27,7 @@ tags:
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
   _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1'
+availableSecrets:
+  secretManager:
+  - versionName: $_TFE_TOKEN_SECRET_ID/versions/latest
+    env: 'TFE_TOKEN'


### PR DESCRIPTION
The TFE_TOKEN secret can be used in relevant steps as:
```
steps:
- name: STEP_NAME
  ...  
  secretEnv: ['TFE_TOKEN']
  ...
```

This should be available as soon as [this PR](https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/pull/1782) is applied.